### PR TITLE
Add tables run_status and step_status instead of PostGreSQL enums

### DIFF
--- a/hasura/metadata/databases/default/tables/simpipe_run_status.yaml
+++ b/hasura/metadata/databases/default/tables/simpipe_run_status.yaml
@@ -1,0 +1,4 @@
+table:
+  name: run_status
+  schema: simpipe
+is_enum: true

--- a/hasura/metadata/databases/default/tables/simpipe_step_status.yaml
+++ b/hasura/metadata/databases/default/tables/simpipe_step_status.yaml
@@ -1,0 +1,4 @@
+table:
+  name: step_status
+  schema: simpipe
+is_enum: true

--- a/hasura/metadata/databases/default/tables/tables.yaml
+++ b/hasura/metadata/databases/default/tables/tables.yaml
@@ -1,6 +1,8 @@
 - "!include simpipe_cpu.yaml"
 - "!include simpipe_logs.yaml"
 - "!include simpipe_memory.yaml"
+- "!include simpipe_run_status.yaml"
 - "!include simpipe_runs.yaml"
 - "!include simpipe_simulations.yaml"
+- "!include simpipe_step_status.yaml"
 - "!include simpipe_steps.yaml"

--- a/hasura/migrations/default/1642516281436_new_status_tables/down.sql
+++ b/hasura/migrations/default/1642516281436_new_status_tables/down.sql
@@ -1,0 +1,54 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- ALTER TABLE simpipe.runs DROP CONSTRAINT "ended started constraint";
+--
+-- ALTER TABLE simpipe.runs ALTER COLUMN status TYPE text;
+-- ALTER TABLE simpipe.steps ALTER COLUMN status TYPE text;
+--
+-- ALTER TABLE simpipe.runs ALTER COLUMN status SET DEFAULT 'waiting';
+-- ALTER TABLE simpipe.steps ALTER COLUMN status SET DEFAULT 'waiting';
+--
+-- DROP TYPE simpipe.run_status;
+-- DROP TYPE simpipe.step_status;
+--
+-- ALTER TABLE simpipe.runs ADD CONSTRAINT "ended started constraint" CHECK (
+--   (status = 'waiting' AND (started IS NULL) AND (ended IS NULL)) OR
+--   (status = 'active' AND (started IS NOT NULL) AND (ended IS NULL)) OR
+--   (status = 'completed' AND (started IS NOT NULL) AND (ended IS NOT NULL)) OR
+--   ((status = 'failed' OR status = 'cancelled') AND
+--     ((ended IS NULL) OR (started IS NOT NULL))));
+--
+-- ALTER TABLE simpipe.steps ADD CONSTRAINT "ended started constraint" CHECK (
+--   (status = 'waiting' AND (started IS NULL) AND (ended IS NULL)) OR
+--   (status = 'active' AND (started IS NOT NULL) AND (ended IS NULL)) OR
+--   (status = 'completed' AND (started IS NOT NULL) AND (ended IS NOT NULL)) OR
+--   ((status = 'failed' OR status = 'cancelled') AND
+--     ((ended IS NULL) OR (started IS NOT NULL))));
+--
+-- CREATE TABLE simpipe.run_status (
+--   value text PRIMARY KEY
+-- );
+--
+-- INSERT INTO simpipe.run_status (value) VALUES
+--   ('waiting'),
+--   ('active'),
+--   ('completed'),
+--   ('failed'),
+--   ('cancelled');
+--
+-- CREATE TABLE simpipe.step_status (
+--   value text PRIMARY KEY
+-- );
+--
+-- INSERT INTO simpipe.step_status (value) VALUES
+--   ('waiting'),
+--   ('active'),
+--   ('completed'),
+--   ('failed'),
+--   ('cancelled');
+--
+-- ALTER TABLE simpipe.runs ADD CONSTRAINT
+--   run_status_fkey FOREIGN KEY (status) REFERENCES simpipe.run_status;
+--
+-- ALTER TABLE simpipe.steps ADD CONSTRAINT
+--   run_status_fkey FOREIGN KEY (status) REFERENCES simpipe.step_status;

--- a/hasura/migrations/default/1642516281436_new_status_tables/up.sql
+++ b/hasura/migrations/default/1642516281436_new_status_tables/up.sql
@@ -1,0 +1,52 @@
+ALTER TABLE simpipe.runs DROP CONSTRAINT "ended started constraint";
+
+ALTER TABLE simpipe.runs ALTER COLUMN status TYPE text;
+ALTER TABLE simpipe.steps ALTER COLUMN status TYPE text;
+
+ALTER TABLE simpipe.runs ALTER COLUMN status SET DEFAULT 'waiting';
+ALTER TABLE simpipe.steps ALTER COLUMN status SET DEFAULT 'waiting';
+
+DROP TYPE simpipe.run_status;
+DROP TYPE simpipe.step_status;
+
+ALTER TABLE simpipe.runs ADD CONSTRAINT "ended started constraint" CHECK (
+  (status = 'waiting' AND (started IS NULL) AND (ended IS NULL)) OR 
+  (status = 'active' AND (started IS NOT NULL) AND (ended IS NULL)) OR
+  (status = 'completed' AND (started IS NOT NULL) AND (ended IS NOT NULL)) OR
+  ((status = 'failed' OR status = 'cancelled') AND
+    ((ended IS NULL) OR (started IS NOT NULL))));
+
+ALTER TABLE simpipe.steps ADD CONSTRAINT "ended started constraint" CHECK (
+  (status = 'waiting' AND (started IS NULL) AND (ended IS NULL)) OR 
+  (status = 'active' AND (started IS NOT NULL) AND (ended IS NULL)) OR
+  (status = 'completed' AND (started IS NOT NULL) AND (ended IS NOT NULL)) OR
+  ((status = 'failed' OR status = 'cancelled') AND
+    ((ended IS NULL) OR (started IS NOT NULL))));
+
+CREATE TABLE simpipe.run_status (
+  value text PRIMARY KEY
+);
+
+INSERT INTO simpipe.run_status (value) VALUES
+  ('waiting'),
+  ('active'),
+  ('completed'),
+  ('failed'),
+  ('cancelled');
+
+CREATE TABLE simpipe.step_status (
+  value text PRIMARY KEY
+);
+
+INSERT INTO simpipe.step_status (value) VALUES
+  ('waiting'),
+  ('active'),
+  ('completed'),
+  ('failed'),
+  ('cancelled');
+
+ALTER TABLE simpipe.runs ADD CONSTRAINT
+  run_status_fkey FOREIGN KEY (status) REFERENCES simpipe.run_status;
+
+ALTER TABLE simpipe.steps ADD CONSTRAINT
+  run_status_fkey FOREIGN KEY (status) REFERENCES simpipe.step_status;


### PR DESCRIPTION
As recommended by the Hasura documentation, it's better to use enum tables than PostGreSQL enum types.